### PR TITLE
Add a fake router for live environment

### DIFF
--- a/ci/README.markdown
+++ b/ci/README.markdown
@@ -10,7 +10,7 @@ Scripts:
 
 - `./create.sh` - run `deploy-ci.sh` and `build-all-apps.sh` scripts
 - `./deploy-ci.sh` - deploy pipelines to Concourse
-- `./build-all-apps.sh` - trigger a build all apps
+- `./build-all-apps.sh` - trigger a build of all apps
 
 
 Pipelines

--- a/ci/build-all-apps.sh
+++ b/ci/build-all-apps.sh
@@ -10,3 +10,4 @@ if [[ -z "$FLY_LOGGED_IN" ]]; then
 fi
 
 fly trigger-job -t govuk-k8s -j ci/govuk-base
+fly trigger-job -t govuk-k8s -j ci/fake-router

--- a/ci/pipelines/generate-ci-yaml.py
+++ b/ci/pipelines/generate-ci-yaml.py
@@ -110,15 +110,31 @@ pipeline = {
         ),
         image_resource("govuk-base"),
         image_resource("ruby-2-6-5"),
+        image_resource("fake-router"),
     ],
     "jobs": [
         build_base_image("govuk-base", base_image=None),
         build_base_image("ruby-2-6-5"),
+        {
+            "name": "fake-router",
+            "serial": True,
+            "plan": [
+                {"get": "govuk-base-git"},
+                {
+                    "put": f"fake-router-image",
+                    "params": {
+                        "build": "govuk-base-git/util/fake-router",
+                        "tag_as_latest": True,
+                    },
+                },
+            ],
+        },
     ],
     "groups": [
         {"name": "CI", "jobs": ["govuk-base", "ruby-2-6-5"]},
         {"name": "Frontend", "jobs": frontend_apps},
         {"name": "API", "jobs": api_apps},
+        {"name": "Miscellaneous", "jobs": ["fake-router"]},
     ],
 }
 

--- a/kubernetes/README.markdown
+++ b/kubernetes/README.markdown
@@ -91,9 +91,10 @@ stringData:
 See `live/secrets.yaml.template` and `govuk/secrets.yaml.template` to
 see the concrete values for the `"..."` placeholders.
 
-There are two template variables expanded by `deploy.sh` to produce
+There are some template variables expanded by `deploy.sh` to produce
 the final `secrets.yaml`:
 
+- `TPL_ENABLE_HTTPS`: set to the `ENABLE_HTTPS` in `../config`
 - `TPL_EXTERNAL_DOMAIN_NAME`: set to the `EXTERNAL_DOMAIN_NAME` in `../config`
 - `TPL_UUID`: set to a random uuid, with each `TPL_UUID` different
 

--- a/kubernetes/apps/fake-router.deployment.yaml
+++ b/kubernetes/apps/fake-router.deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-router
+spec:
+  selector:
+    matchLabels:
+      run: fake-router
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: fake-router
+    spec:
+      containers:
+        - name: fake-router
+          image: registry.govuk-k8s.test:5000/fake-router
+          env:
+            - name: PLEK_SERVICE_CONTENT_STORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: govuk
+                  key: PLEK_SERVICE_CONTENT_STORE_URI
+            - name: FAKE_ROUTER_HTTPS
+              valueFrom:
+                secretKeyRef:
+                  name: govuk
+                  key: FAKE_ROUTER_HTTPS
+            - name: FAKE_ROUTER_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: govuk
+                  key: FAKE_ROUTER_DOMAIN
+          ports:
+            - containerPort: 3000
+              protocol: TCP

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -20,6 +20,7 @@ source ../config
 pushd "$NAMESPACE"
 
 cp secrets.yaml.template secrets.yaml
+sed -i "s/TPL_ENABLE_HTTPS/${ENABLE_HTTPS}/" secrets.yaml
 sed -i "s/TPL_EXTERNAL_DOMAIN_NAME/${EXTERNAL_DOMAIN_NAME}/" secrets.yaml
 
 # generate a fresh SECRET_KEY_BASE every time

--- a/kubernetes/live/fake-router.service.yaml
+++ b/kubernetes/live/fake-router.service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fake-router
+spec:
+  selector:
+    run: fake-router
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+      nodePort: 31000
+  type: NodePort

--- a/kubernetes/live/secrets.yaml.template
+++ b/kubernetes/live/secrets.yaml.template
@@ -11,6 +11,8 @@ stringData:
   PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
   PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
   PLEK_SERVICE_WHITEHALL_ADMIN_URI: https://www.gov.uk
+  FAKE_ROUTER_HTTPS: "TPL_ENABLE_HTTPS"
+  FAKE_ROUTER_DOMAIN: live.web.TPL_EXTERNAL_DOMAIN_NAME
   K8S_HOSTNAMES-calculators: calculators.live.web.TPL_EXTERNAL_DOMAIN_NAME
   K8S_HOSTNAMES-calendars: calendars.live.web.TPL_EXTERNAL_DOMAIN_NAME
   K8S_HOSTNAMES-collections: collections.live.web.TPL_EXTERNAL_DOMAIN_NAME

--- a/provisioning/nixos/web.nix
+++ b/provisioning/nixos/web.nix
@@ -115,6 +115,7 @@ in
       "release.${domain}"                      = govuk_virtualhost ports.release;
 
       # live: only frontend apps which can be run against live APIs
+      "www-origin.live.${domain}"              = govuk_virtualhost (live_offset + ports.www-origin);
       "calculators.live.${domain}"             = govuk_virtualhost (live_offset + ports.calculators);
       "calendars.live.${domain}"               = govuk_virtualhost (live_offset + ports.calendars);
       "collections.live.${domain}"             = govuk_virtualhost (live_offset + ports.collections);

--- a/util/fake-router/Dockerfile
+++ b/util/fake-router/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+CMD python app.py

--- a/util/fake-router/app.py
+++ b/util/fake-router/app.py
@@ -1,0 +1,34 @@
+from flask import Flask, abort, redirect
+
+import os
+import requests
+
+FAKE_ROUTER_HTTPS = os.getenv("FAKE_ROUTER_HTTPS", default="false") == "true"
+FAKE_ROUTER_DOMAIN = os.environ["FAKE_ROUTER_DOMAIN"]
+PLEK_SERVICE_CONTENT_STORE_URI = os.getenv(
+    "PLEK_SERVICE_CONTENT_STORE_URI", default="https://www.gov.uk/api"
+)
+
+app = Flask(__name__)
+
+
+def url_for(rendering_app, path):
+    protocol = "https" if FAKE_ROUTER_HTTPS else "http"
+    return f"{protocol}://{rendering_app}.{FAKE_ROUTER_DOMAIN}/{path}"
+
+
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
+def redirect_to_backend(path):
+    r = requests.get(f"{PLEK_SERVICE_CONTENT_STORE_URI}/content/{path}")
+    if r.status_code == 404:
+        abort(404)
+    try:
+        rendering_app = r.json()["rendering_app"]
+        return redirect(url_for(rendering_app, path))
+    except:
+        abort(500)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port="3000")

--- a/util/fake-router/requirements.txt
+++ b/util/fake-router/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
fake-router looks up a path in the content API and uses that to determine where to send the request:

```
$ curl -i http://www-origin.live.web.govuk-k8s.barrucadu.co.uk/vehicle-tax
HTTP/1.1 302 FOUND
Server: nginx
Date: Fri, 15 Nov 2019 19:34:27 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 331
Connection: keep-alive
Location: http://frontend.live.web.govuk-k8s.barrucadu.co.uk/vehicle-tax

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="http://frontend.live.web.govuk-k8s.barrucadu.co.uk/vehicle-tax">http://frontend.live.web.govuk-k8s.barrucadu.co.uk/vehicle-tax</a>.  If not click the link.
```

It's a "fake" router because it doesn't proxy to the host, it only redirects; also it can only route things which exist as exact paths in the content store, it can't handle prefix routes (or anything else special which only exists in router-api) at all.